### PR TITLE
Add timezone offset and reduce memory consumption

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,41 +93,7 @@ or previews, provide a lower priority such as ``--priority 30``
 copy is unavailable. Alternate versions are matched using their
 timestamp and filename.
 
-Old versions of the database are given unique names and not overwritten.
-
-The database takes this form:
-
-.. code-block:: json
-
-    {
-      "version": 1,
-      "hash_algorithm": "blake2b-256",
-      "timezone_default": "local",
-      "photo_db": {
-        "<uid>": [
-          "<photo>",
-          "<photo>",
-          "..."
-        ]
-      },
-      "command_history": {
-        "<timestamp>": "<command>"
-      }
-    }
-
-where an example photo has the form:
-
-.. code-block:: json
-
-    {
-      "checksum": "881f279108bcec5b6e...",
-      "source_path": "/path/to/photo_123.jpg",
-      "datetime": "2021:03:29 06:40:00+00:00",
-      "timestamp": 1617000000,
-      "file_size": 123456,
-      "store_path": "2021/03-Mar/2021-03-29_02-40-00-881f279-photo_123.jpg",
-      "priority": 10
-    }
+Previous versions of the database are given unique names and not overwritten.
 
 If the photos are stored on an SSD or RAID array, use
 ``--storage-type SSD`` or ``--storage-type RAID`` and
@@ -304,3 +270,53 @@ Remove unnecessary duplicates
       --debug                  Run in debug mode
       --dry-run                Perform a dry run that makes no changes
       --help                   Show this message and exit.
+
+Database file format
+====================
+
+The database is a json file, optionally gzip or zstd-compressed.
+It takes this form:
+
+.. code-block:: json
+
+    {
+      "version": 1,
+      "hash_algorithm": "blake2b-256",
+      "timezone_default": "local",
+      "photo_db": {
+        "<uid>": [
+          "<photo>",
+          "<photo>",
+          "..."
+        ]
+      },
+      "command_history": {
+        "<timestamp>": "<command>"
+      }
+    }
+
+where an example photo has the form:
+
+.. code-block:: json
+
+    {
+      "chk": "iB8nkQi87Ftu...",
+      "src": "/path/to/photo_123.jpg",
+      "dt": "2021:03:29 06:40:00+00:00",
+      "ts": 1617000000,
+      "fsz": 123456,
+      "sto": "2021/03-Mar/2021-03-29_02-40-00-881f279-photo_123.jpg",
+      "prio": 10,
+      "tzo": -14400.0
+    }
+
+Attributes:
+
+    :chk (str): checksum of photo file (base64-encoded)
+    :src (str): Absolute path where photo was found
+    :dt (str): Datetime string for best estimated creation date (original)
+    :ts (float): POSIX timestamp of best estimated creation date (derived)
+    :fsz (int): Photo file size, in bytes
+    :sto (str): Relative path where photo is stored, empty if not stored
+    :prio (int): Photo priority (lower is preferred)
+    :tzo (float): local time zone offset

--- a/README.rst
+++ b/README.rst
@@ -300,7 +300,7 @@ where an example photo has the form:
 .. code-block:: json
 
     {
-      "chk": "iB8nkQi87Ftu...",
+      "chk": "881f279108bcec5b6e...",
       "src": "/path/to/photo_123.jpg",
       "dt": "2021:03:29 06:40:00+00:00",
       "ts": 1617000000,
@@ -312,7 +312,7 @@ where an example photo has the form:
 
 Attributes:
 
-    :chk (str): checksum of photo file (base64-encoded)
+    :chk (str): checksum of photo file
     :src (str): Absolute path where photo was found
     :dt (str): Datetime string for best estimated creation date (original)
     :ts (float): POSIX timestamp of best estimated creation date (derived)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,6 @@ click>=7.1.2
 orjson>=3.5.2
 zstandard>=0.15.2
 xxhash>=2.0.2
-pybase64>=1.1.4
 pytest
 pytest-datafiles
 tox

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ click>=7.1.2
 orjson>=3.5.2
 zstandard>=0.15.2
 xxhash>=2.0.2
+pybase64>=1.1.4
 pytest
 pytest-datafiles
 tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,6 @@ install_requires =
     orjson>=3.5.2
     zstandard>=0.15.2
     xxhash>=2.0.2
-    pybase64>=1.1.4
 python_requires = >=3.8
 package_dir =
     = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ install_requires =
     orjson>=3.5.2
     zstandard>=0.15.2
     xxhash>=2.0.2
+    pybase64>=1.1.4
 python_requires = >=3.8
 package_dir =
     = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -127,6 +127,7 @@ exclude_lines =
     pragma: no cover
     if TYPE_CHECKING:
     raise NotImplementedError
+    if __name__ == .__main__.:
     # typing-related code
     ^if (False|TYPE_CHECKING):
     : \\.\\.\\.$

--- a/src/photomanager/cli.py
+++ b/src/photomanager/cli.py
@@ -83,6 +83,9 @@ def _create(
               help="Name patterns to exclude")
 @click.option("--priority", type=int, default=10,
               help="Priority of indexed photos (lower is preferred, default=10)")
+@click.option("--timezone-default", type=str, default=None,
+              help="Timezone to use when indexing timezone-naive photos "
+                   "(example=\"-0400\", default=\"local\")")
 @click.option("--storage-type", type=str, default="HDD",
               help="Class of storage medium (HDD, SSD, RAID)")
 @click.option("--debug", default=False, is_flag=True,
@@ -100,6 +103,7 @@ def _index(
     debug=False,
     dry_run=False,
     priority=10,
+    timezone_default: Optional[str] = None,
     storage_type="HDD",
 ):
     if not source and not file and not paths:
@@ -110,7 +114,10 @@ def _index(
     database = Database.from_file(db, create_new=True)
     filtered_files = list_files(source=source, file=file, exclude=exclude, paths=paths)
     database.index_photos(
-        files=filtered_files, priority=priority, storage_type=storage_type
+        files=filtered_files,
+        priority=priority,
+        storage_type=storage_type,
+        timezone_default=timezone_default,
     )
     database.add_command(shlex.join(sys.argv))
     if not dry_run:

--- a/src/photomanager/database.py
+++ b/src/photomanager/database.py
@@ -27,7 +27,7 @@ from photomanager.hasher import (
     DEFAULT_HASH_ALGO,
     HashAlgorithm,
 )
-from photomanager.photofile import PhotoFile, checksum_encode, NAME_MAP_ENC
+from photomanager.photofile import PhotoFile, NAME_MAP_ENC
 
 
 unit_list = list(zip(["bytes", "kB", "MB", "GB", "TB", "PB"], [0, 0, 1, 2, 2, 2]))
@@ -161,7 +161,7 @@ class Database:
                 for i in range(len(photos)):
                     checksum = photos[i]["checksum"]
                     checksum = checksum.split(":", 1)[0]
-                    photos[i]["checksum"] = checksum_encode(bytes.fromhex(checksum))
+                    photos[i]["checksum"] = checksum.split(":", 1)[0]
                     photos[i] = {NAME_MAP_ENC[k]: v for k, v in photos[i].items()}
 
         db = {k: db[k] for k in self.DB_KEY_ORDER}
@@ -369,6 +369,7 @@ class Database:
         """
         Generate a new uid that is not in the photo_db.
         8 base58 characters = 10^14 possible uids.
+        P(collision) ≈ 50% at 1 million uids, so we must check for collisions.
         """
         next_uid = "".join(random.choices(self.UID_ALPHABET, k=8))
         if next_uid in self.photo_db:  # pragma: no cover

--- a/src/photomanager/photofile.py
+++ b/src/photomanager/photofile.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from os import PathLike
+from os.path import getsize
+from datetime import datetime, tzinfo, timezone, timedelta
+from dataclasses import dataclass, asdict, field, fields
+from typing import Union, Optional, Type, TypeVar, ClassVar
+
+from photomanager.pyexiftool import ExifTool
+from photomanager.hasher import file_checksum, DEFAULT_HASH_ALGO
+
+PF = TypeVar("PF", bound="PhotoFile")
+local_tzoffset = datetime.now().astimezone().utcoffset().total_seconds()
+ALIAS_METADATA = "json_name"
+NAME_MAP_ENC: ClassVar[dict[str, str]] = {
+    "checksum": "chk",
+    "source_path": "src",
+    "datetime": "dt",
+    "timestamp": "ts",
+    "file_size": "fsz",
+    "store_path": "sto",
+    "priority": "prio",
+    "tz_offset": "tzo",
+}
+NAME_MAP_DEC: ClassVar[dict[str, str]] = {v: k for k, v in NAME_MAP_ENC.items()}
+
+
+@dataclass
+class PhotoFile:
+    """A dataclass describing a photo or other media file
+
+    Attributes:
+        :checksum (str): checksum of photo file
+        :source_path (str): Absolute path where photo was found
+        :datetime (str): Datetime string for best estimated creation date (original)
+        :timestamp (float): POSIX timestamp of best estimated creation date (derived)
+        :file_size (int): Photo file size, in bytes
+        :store_path (str): Relative path where photo is stored, empty if not stored
+        :priority (int): Photo priority (lower is preferred)
+        :tz_offset (float): local time offset
+    """
+
+    checksum: str = field(metadata={ALIAS_METADATA: NAME_MAP_ENC["checksum"]})
+    source_path: str = field(metadata={ALIAS_METADATA: NAME_MAP_ENC["source_path"]})
+    datetime: str = field(metadata={ALIAS_METADATA: NAME_MAP_ENC["datetime"]})
+    timestamp: float = field(metadata={ALIAS_METADATA: NAME_MAP_ENC["timestamp"]})
+    file_size: int = field(metadata={ALIAS_METADATA: NAME_MAP_ENC["file_size"]})
+    store_path: str = field(
+        default="", metadata={ALIAS_METADATA: NAME_MAP_ENC["store_path"]}
+    )
+    priority: int = field(
+        default=10, metadata={ALIAS_METADATA: NAME_MAP_ENC["priority"]}
+    )
+    tz_offset: float = field(
+        default=None, metadata={ALIAS_METADATA: NAME_MAP_ENC["tz_offset"]}
+    )
+
+    def __getattribute__(self, attr):
+        if attr == "__dict__":
+            return {
+                f.metadata.get(ALIAS_METADATA, f.name): getattr(self, f.name)
+                for f in fields(self)
+            }
+        return super().__getattribute__(attr)
+
+    @property
+    def local_datetime(self):
+        tz = (
+            timezone(timedelta(seconds=self.tz_offset))
+            if self.tz_offset is not None
+            else None
+        )
+        return datetime.fromtimestamp(self.timestamp).astimezone(tz)
+
+    @classmethod
+    def from_file(
+            cls: Type[PF],
+            source_path: Union[str, PathLike],
+            algorithm: str = DEFAULT_HASH_ALGO,
+            tz_default: Optional[tzinfo] = None,
+            priority: int = 10,
+    ) -> PF:
+        """Create a PhotoFile for a given file
+
+        :param source_path: The path to the file
+        :param algorithm: The hashing algorithm to use
+        :param tz_default: The time zone to use if none is set
+            (defaults to local time)
+        :param priority: The photo's priority
+        """
+        photo_hash: str = file_checksum(source_path, algorithm)
+        dt_str = get_media_datetime(source_path)
+        dt = datetime_str_to_object(dt_str, tz_default=tz_default)
+        tz = dt.utcoffset().total_seconds() if dt.tzinfo is not None else local_tzoffset
+        timestamp = dt.timestamp()
+        file_size = getsize(source_path)
+        return cls(
+            checksum=photo_hash,
+            source_path=str(source_path),
+            datetime=dt_str,
+            timestamp=timestamp,
+            file_size=file_size,
+            store_path="",
+            priority=priority,
+            tz_offset=tz,
+        )
+
+    @classmethod
+    def from_file_cached(
+            cls: Type[PF],
+            source_path: str,
+            checksum_cache: dict[str, str],
+            datetime_cache: dict[str, str],
+            algorithm: str = DEFAULT_HASH_ALGO,
+            tz_default: Optional[tzinfo] = None,
+            priority: int = 10,
+    ) -> PF:
+        """Create a PhotoFile for a given file
+
+        If source_path is in the checksum and datetime caches, uses the cached value
+        instead of reading from the file.
+
+        :param source_path: The path to the file
+        :param checksum_cache: A mapping of source paths to known checksums
+        :param datetime_cache: A mapping of source paths to datetime strings
+        :param algorithm: The hashing algorithm to use for new checksums
+        :param tz_default: The time zone to use if none is set
+            (defaults to local time)
+        :param priority: The photo's priority
+        """
+        photo_hash: str = (
+            checksum_cache[source_path]
+            if source_path in checksum_cache
+            else file_checksum(source_path, algorithm)
+        )
+        dt_str = (
+            datetime_cache[source_path]
+            if source_path in datetime_cache
+            else get_media_datetime(source_path)
+        )
+        dt = datetime_str_to_object(dt_str, tz_default=tz_default)
+        tz = dt.utcoffset().total_seconds() if dt.tzinfo else None
+        timestamp = dt.timestamp()
+        file_size = getsize(source_path)
+        return cls(
+            checksum=photo_hash,
+            source_path=str(source_path),
+            datetime=dt_str,
+            timestamp=timestamp,
+            file_size=file_size,
+            store_path="",
+            priority=priority,
+            tz_offset=tz,
+        )
+
+    @classmethod
+    def from_dict(cls: Type[PF], d: dict) -> PF:
+        if "checksum" not in d:  # we are dealing with encoded names
+            d = {NAME_MAP_DEC[k]: v for k, v in d.items()}
+        return cls(**d)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def datetime_str_to_object(ts_str: str, tz_default: tzinfo = None) -> datetime:
+    """Parses a datetime string into a datetime object"""
+    dt = None
+    if "." in ts_str:
+        for fmt in ("%Y:%m:%d %H:%M:%S.%f%z", "%Y:%m:%d %H:%M:%S.%f"):
+            try:
+                dt = datetime.strptime(ts_str, fmt)
+            except ValueError:
+                pass
+    else:
+        for fmt in (
+                "%Y:%m:%d %H:%M:%S%z",
+                "%Y:%m:%d %H:%M:%S",
+                "%Y:%m:%d %H:%M%z",
+                "%Y:%m:%d %H:%M",
+        ):
+            try:
+                dt = datetime.strptime(ts_str, fmt)
+            except ValueError:
+                pass
+    if dt is not None:
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=tz_default)
+        return dt
+    raise ValueError(f"Could not parse datetime str: {repr(ts_str)}")
+
+
+def get_media_datetime(path: Union[str, PathLike]) -> str:
+    """Gets the best known datetime string for a file"""
+    return ExifTool().get_best_datetime(path)

--- a/src/photomanager/photofile.py
+++ b/src/photomanager/photofile.py
@@ -6,8 +6,6 @@ from datetime import datetime, tzinfo, timezone, timedelta
 from dataclasses import dataclass, asdict, fields
 from typing import Union, Optional, Type, TypeVar
 
-from pybase64 import b64decode, b64encode
-
 from photomanager.pyexiftool import ExifTool
 from photomanager.hasher import file_checksum, DEFAULT_HASH_ALGO, HashAlgorithm
 
@@ -24,14 +22,6 @@ NAME_MAP_ENC: dict[str, str] = {
     "tz_offset": "tzo",
 }
 NAME_MAP_DEC: dict[str, str] = {v: k for k, v in NAME_MAP_ENC.items()}
-
-
-def checksum_encode(checksum: bytes) -> str:
-    return b64encode(checksum).decode()
-
-
-def checksum_decode(checksum: str) -> bytes:
-    return b64decode(checksum, validate=True)
 
 
 @dataclass
@@ -61,7 +51,7 @@ class PhotoFile:
     @property
     def __dict__(self):
         d = {f.name: getattr(self, f.name) for f in fields(self)}
-        d["chk"] = checksum_encode(d["chk"])
+        d["chk"] = d["chk"].hex()
         return d
 
     @property
@@ -152,7 +142,7 @@ class PhotoFile:
 
     @classmethod
     def from_json_dict(cls: Type[PF], d: dict) -> PF:
-        d["chk"] = checksum_decode(d["chk"])
+        d["chk"] = bytes.fromhex(d["chk"])
         return cls.from_dict(d)
 
     @classmethod

--- a/tests/integ_tests/test_cli.py
+++ b/tests/integ_tests/test_cli.py
@@ -115,7 +115,7 @@ def test_cli_import(datafiles, caplog):
             assert db.hash_to_uid[checksum] in db.photo_db
             photos = db.photo_db[db.hash_to_uid[checksum]]
             assert len(photos) == 1
-            assert photos[0].source_path == datafiles / rel_path
+            assert photos[0].src == datafiles / rel_path
 
         result = runner.invoke(
             cast(Group, cli.main),
@@ -146,7 +146,7 @@ def test_cli_import(datafiles, caplog):
             assert db.hash_to_uid[checksum] in db.photo_db
             photos = db.photo_db[db.hash_to_uid[checksum]]
             assert len(photos) == 2
-            assert photos[1].source_path == datafiles / rel_path
+            assert photos[1].src == datafiles / rel_path
 
         caplog.set_level(logging.INFO)
         s_prev = s
@@ -201,7 +201,7 @@ def test_cli_import(datafiles, caplog):
             assert db.hash_to_uid[checksum] in db.photo_db
             photos = db.photo_db[db.hash_to_uid[checksum]]
             assert len(photos) == 1
-            assert photos[0].source_path == datafiles / rel_path
+            assert photos[0].src == datafiles / rel_path
 
         db_prev = db
         result = runner.invoke(
@@ -265,20 +265,20 @@ def test_cli_import(datafiles, caplog):
             assert db.hash_to_uid[checksum] in db.photo_db
             photos = db.photo_db[db.hash_to_uid[checksum]]
             if rel_path.startswith("A"):
-                assert photos[0].source_path == datafiles / rel_path
-                assert photos[0].store_path != ""
+                assert photos[0].src == datafiles / rel_path
+                assert photos[0].sto != ""
                 assert abs_path.exists()
-                assert (datafiles / "pm_store" / photos[0].store_path).exists()
+                assert (datafiles / "pm_store" / photos[0].sto).exists()
             elif rel_path.startswith("B"):
                 assert len(photos) == 2
-                assert photos[1].source_path == datafiles / rel_path
-                assert photos[1].store_path == ""
+                assert photos[1].src == datafiles / rel_path
+                assert photos[1].sto == ""
             elif rel_path.startswith("C"):
                 assert len(photos) == 1
-                assert photos[0].source_path == datafiles / rel_path
-                assert photos[0].store_path != ""
+                assert photos[0].src == datafiles / rel_path
+                assert photos[0].sto != ""
                 assert abs_path.exists()
-                assert (datafiles / "pm_store" / photos[0].store_path).exists()
+                assert (datafiles / "pm_store" / photos[0].sto).exists()
 
         result = runner.invoke(
             cast(Group, cli.main),
@@ -307,40 +307,40 @@ def test_cli_import(datafiles, caplog):
                 pf
                 for photos in db.photo_db.values()
                 for pf in photos
-                if pf.store_path and pf.checksum == EXPECTED_HASHES["A/img1.jpg"]
+                if pf.sto and pf.chk == EXPECTED_HASHES["A/img1.jpg"]
             )
-            img1_jpg.store_path = ""
+            img1_jpg.sto = ""
             img2_jpg = next(
                 pf
                 for photos in db.photo_db.values()
                 for pf in photos
-                if pf.store_path and pf.checksum == EXPECTED_HASHES["A/img2.jpg"]
+                if pf.sto and pf.chk == EXPECTED_HASHES["A/img2.jpg"]
             )
-            os.remove(img2_jpg.source_path)
-            os.remove(datafiles / "pm_store" / img2_jpg.store_path)
+            os.remove(img2_jpg.src)
+            os.remove(datafiles / "pm_store" / img2_jpg.sto)
             img2_png = next(
                 pf
                 for photos in db.photo_db.values()
                 for pf in photos
-                if pf.store_path and pf.checksum == EXPECTED_HASHES["A/img1.png"]
+                if pf.sto and pf.chk == EXPECTED_HASHES["A/img1.png"]
             )
-            os.remove(img2_png.source_path)
+            os.remove(img2_png.src)
             img3_tiff = next(
                 pf
                 for photos in db.photo_db.values()
                 for pf in photos
-                if pf.store_path and pf.checksum == EXPECTED_HASHES["C/img3.tiff"]
+                if pf.sto and pf.chk == EXPECTED_HASHES["C/img3.tiff"]
             )
-            os.remove(datafiles / "pm_store" / img3_tiff.store_path)
+            os.remove(datafiles / "pm_store" / img3_tiff.sto)
             img4_jpg = next(
                 pf
                 for photos in db.photo_db.values()
                 for pf in photos
-                if pf.store_path and pf.checksum == EXPECTED_HASHES["A/img4.jpg"]
+                if pf.sto and pf.chk == EXPECTED_HASHES["A/img4.jpg"]
             )
-            os.remove(img4_jpg.source_path)
-            os.remove(datafiles / "pm_store" / img4_jpg.store_path)
-            img4_jpg.store_path = ""
+            os.remove(img4_jpg.src)
+            os.remove(datafiles / "pm_store" / img4_jpg.sto)
+            img4_jpg.sto = ""
             f.seek(0)
             s = db.to_json(pretty=True)
             f.write(s)
@@ -396,25 +396,25 @@ def test_cli_import(datafiles, caplog):
             assert db.hash_to_uid[checksum] in db.photo_db
             photos = db.photo_db[db.hash_to_uid[checksum]]
             if rel_path == "A/img2.jpg":
-                assert photos[0].source_path == datafiles / rel_path
-                assert photos[0].store_path != ""
-                assert not (datafiles / "pm_store" / photos[0].store_path).exists()
+                assert photos[0].src == datafiles / rel_path
+                assert photos[0].sto != ""
+                assert not (datafiles / "pm_store" / photos[0].sto).exists()
             elif rel_path == "A/img4.jpg":
-                assert photos[0].source_path == datafiles / rel_path
-                assert photos[0].store_path == ""
+                assert photos[0].src == datafiles / rel_path
+                assert photos[0].sto == ""
             elif rel_path.startswith("A"):
-                assert photos[0].source_path == datafiles / rel_path
-                assert photos[0].store_path != ""
-                assert (datafiles / "pm_store" / photos[0].store_path).exists()
+                assert photos[0].src == datafiles / rel_path
+                assert photos[0].sto != ""
+                assert (datafiles / "pm_store" / photos[0].sto).exists()
             elif rel_path.startswith("B"):
                 assert len(photos) == 2
-                assert photos[1].source_path == datafiles / rel_path
-                assert photos[1].store_path == ""
+                assert photos[1].src == datafiles / rel_path
+                assert photos[1].sto == ""
             elif rel_path.startswith("C"):
                 assert len(photos) == 1
-                assert photos[0].source_path == datafiles / rel_path
-                assert photos[0].store_path != ""
-                assert (datafiles / "pm_store" / photos[0].store_path).exists()
+                assert photos[0].src == datafiles / rel_path
+                assert photos[0].sto != ""
+                assert (datafiles / "pm_store" / photos[0].sto).exists()
         check_dir_empty(fs)
 
 
@@ -490,7 +490,7 @@ def test_cli_import_no_overwrite(datafiles, caplog):
         print(db.db)
 
         assert (
-            next(iter(db.photo_db.values()))[0].store_path
+            next(iter(db.photo_db.values()))[0].sto
             == "2018/08-Aug/2018-08-01_19-28-36-2aca4e7-img3.tiff"
         )
 
@@ -667,10 +667,10 @@ def test_cli_clean(datafiles, caplog):
             assert db.hash_to_uid[checksum] in db.photo_db
             photos = db.photo_db[db.hash_to_uid[checksum]]
             assert len(photos) == 1
-            assert photos[0].source_path == datafiles / rel_path
-            assert photos[0].store_path != ""
+            assert photos[0].src == datafiles / rel_path
+            assert photos[0].sto != ""
             assert abs_path.exists()
-            assert (datafiles / "pm_store" / photos[0].store_path).exists()
+            assert (datafiles / "pm_store" / photos[0].sto).exists()
 
         s_prev = s
         f_prev = set(Path(datafiles / "pm_store").glob("**/*"))
@@ -728,15 +728,15 @@ def test_cli_clean(datafiles, caplog):
             assert db.hash_to_uid[checksum] in db.photo_db
             photos = db.photo_db[db.hash_to_uid[checksum]]
             if rel_path.startswith("A"):
-                assert photos[0].source_path == datafiles / rel_path
+                assert photos[0].src == datafiles / rel_path
                 print(rel_path)
-                assert photos[0].store_path != ""
-                assert (datafiles / "pm_store" / photos[0].store_path).exists()
+                assert photos[0].sto != ""
+                assert (datafiles / "pm_store" / photos[0].sto).exists()
             elif rel_path.startswith("B"):
                 assert len(photos) == 2
-                assert photos[1].source_path == datafiles / rel_path
-                assert photos[1].store_path != ""
-                assert (datafiles / "pm_store" / photos[1].store_path).exists()
+                assert photos[1].src == datafiles / rel_path
+                assert photos[1].sto != ""
+                assert (datafiles / "pm_store" / photos[1].sto).exists()
 
         assert any(
             p.name == "2018-08-01_20-28-36-2b0f304-img4.jpg"
@@ -776,21 +776,21 @@ def test_cli_clean(datafiles, caplog):
             assert db.hash_to_uid[checksum] in db.photo_db
             photos = db.photo_db[db.hash_to_uid[checksum]]
             if rel_path == "A/img4.jpg":
-                assert photos[0].source_path == datafiles / rel_path
-                assert photos[0].store_path != ""
-                assert (datafiles / "pm_store" / photos[0].store_path).exists()
+                assert photos[0].src == datafiles / rel_path
+                assert photos[0].sto != ""
+                assert (datafiles / "pm_store" / photos[0].sto).exists()
             elif rel_path == "B/img4.jpg":
-                assert photos[1].source_path == datafiles / rel_path
-                assert photos[1].store_path == ""
+                assert photos[1].src == datafiles / rel_path
+                assert photos[1].sto == ""
             elif rel_path.startswith("A"):
-                assert photos[0].source_path == datafiles / rel_path
-                assert photos[0].store_path != ""
-                assert (datafiles / "pm_store" / photos[0].store_path).exists()
+                assert photos[0].src == datafiles / rel_path
+                assert photos[0].sto != ""
+                assert (datafiles / "pm_store" / photos[0].sto).exists()
             elif rel_path.startswith("B"):
                 assert len(photos) == 2
-                assert photos[1].source_path == datafiles / rel_path
-                assert photos[1].store_path != ""
-                assert (datafiles / "pm_store" / photos[1].store_path).exists()
+                assert photos[1].src == datafiles / rel_path
+                assert photos[1].sto != ""
+                assert (datafiles / "pm_store" / photos[1].sto).exists()
 
         s_prev = s
         f_prev = set(Path(datafiles / "pm_store").glob("**/*"))
@@ -903,12 +903,12 @@ def test_cli_clean(datafiles, caplog):
             assert db.hash_to_uid[checksum] in db.photo_db
             photos = db.photo_db[db.hash_to_uid[checksum]]
             if rel_path.startswith("A"):
-                assert photos[0].source_path == datafiles / rel_path
-                assert photos[0].store_path != ""
-                assert (datafiles / "pm_store" / photos[0].store_path).exists()
+                assert photos[0].src == datafiles / rel_path
+                assert photos[0].sto != ""
+                assert (datafiles / "pm_store" / photos[0].sto).exists()
             elif rel_path.startswith("B"):
                 assert len(photos) == 2
-                assert photos[1].source_path == datafiles / rel_path
-                assert photos[1].store_path == ""
+                assert photos[1].src == datafiles / rel_path
+                assert photos[1].sto == ""
 
         check_dir_empty(fs)

--- a/tests/integ_tests/test_cli.py
+++ b/tests/integ_tests/test_cli.py
@@ -16,14 +16,30 @@ ALL_IMG_DIRS = pytest.mark.datafiles(
     keep_top_dir=True,
 )
 EXPECTED_HASHES = {
-    "A/img1.jpg": "d090ce7023b57925e7e94fc80372e3434fb1897e00b4452a25930dd1b83648fb",
-    "A/img2.jpg": "3b39f47d51f63e54c76417ee6e04c34bd3ff5ac47696824426dca9e200f03666",
-    "A/img1.png": "1e10df2e3abe4c810551525b6cb2eb805886de240e04cc7c13c58ae208cabfb9",
-    "A/img4.jpg": "79ac4a89fb3d81ab1245b21b11ff7512495debca60f6abf9afbb1e1fbfe9d98c",
-    "B/img1.jpg": "d090ce7023b57925e7e94fc80372e3434fb1897e00b4452a25930dd1b83648fb",
-    "B/img2.jpg": "e9fec87008fd240309b81c997e7ec5491fee8da7eb1a76fc39b8fcafa76bb583",
-    "B/img4.jpg": "2b0f304f86655ebd04272cc5e7e886e400b79a53ecfdc789f75dd380cbcc8317",
-    "C/img3.tiff": "2aca4e78afbcebf2526ad8ac544d90b92991faae22499eec45831ef7be392391",
+    "A/img1.jpg": bytes.fromhex(
+        "d090ce7023b57925e7e94fc80372e3434fb1897e00b4452a25930dd1b83648fb"
+    ),
+    "A/img2.jpg": bytes.fromhex(
+        "3b39f47d51f63e54c76417ee6e04c34bd3ff5ac47696824426dca9e200f03666"
+    ),
+    "A/img1.png": bytes.fromhex(
+        "1e10df2e3abe4c810551525b6cb2eb805886de240e04cc7c13c58ae208cabfb9"
+    ),
+    "A/img4.jpg": bytes.fromhex(
+        "79ac4a89fb3d81ab1245b21b11ff7512495debca60f6abf9afbb1e1fbfe9d98c"
+    ),
+    "B/img1.jpg": bytes.fromhex(
+        "d090ce7023b57925e7e94fc80372e3434fb1897e00b4452a25930dd1b83648fb"
+    ),
+    "B/img2.jpg": bytes.fromhex(
+        "e9fec87008fd240309b81c997e7ec5491fee8da7eb1a76fc39b8fcafa76bb583"
+    ),
+    "B/img4.jpg": bytes.fromhex(
+        "2b0f304f86655ebd04272cc5e7e886e400b79a53ecfdc789f75dd380cbcc8317"
+    ),
+    "C/img3.tiff": bytes.fromhex(
+        "2aca4e78afbcebf2526ad8ac544d90b92991faae22499eec45831ef7be392391"
+    ),
 }
 
 

--- a/tests/integ_tests/test_photofile.py
+++ b/tests/integ_tests/test_photofile.py
@@ -17,20 +17,23 @@ photofile_expected_results = [
         datetime="2015:08:01 18:28:36.90",
         timestamp=1438468116.9,
         file_size=771,
+        tz_offset=-14400.0,
     ),
     database.PhotoFile(
         checksum="3b39f47d51f63e54c76417ee6e04c34bd3ff5ac47696824426dca9e200f03666",
         source_path="A/img2.jpg",
         datetime="2015:08:01 18:28:36.99",
-        timestamp=1438468116.99,
+        timestamp=1438450116.99,
         file_size=771,
+        tz_offset=3600.0,
     ),
     database.PhotoFile(
         checksum="1e10df2e3abe4c810551525b6cb2eb805886de240e04cc7c13c58ae208cabfb9",
         source_path="A/img1.png",
         datetime="2015:08:01 18:28:36.90",
-        timestamp=1438468116.9,
+        timestamp=1438453716.9,
         file_size=382,
+        tz_offset=0.0,
     ),
     database.PhotoFile(
         checksum="79ac4a89fb3d81ab1245b21b11ff7512495debca60f6abf9afbb1e1fbfe9d98c",
@@ -38,6 +41,7 @@ photofile_expected_results = [
         datetime="2018:08:01 20:28:36",
         timestamp=1533169716.0,
         file_size=759,
+        tz_offset=-14400.0,
     ),
     database.PhotoFile(
         checksum="d090ce7023b57925e7e94fc80372e3434fb1897e00b4452a25930dd1b83648fb",
@@ -45,6 +49,7 @@ photofile_expected_results = [
         datetime="2015:08:01 18:28:36.90",
         timestamp=1438468116.9,
         file_size=771,
+        tz_offset=-14400.0,
     ),
     database.PhotoFile(
         checksum="e9fec87008fd240309b81c997e7ec5491fee8da7eb1a76fc39b8fcafa76bb583",
@@ -52,6 +57,7 @@ photofile_expected_results = [
         datetime="2015:08:01 18:28:36.99",
         timestamp=1438468116.99,
         file_size=789,
+        tz_offset=-14400.0,
     ),
     database.PhotoFile(
         checksum="2b0f304f86655ebd04272cc5e7e886e400b79a53ecfdc789f75dd380cbcc8317",
@@ -59,6 +65,7 @@ photofile_expected_results = [
         datetime="2018:08:01 20:28:36",
         timestamp=1533169716.0,
         file_size=777,
+        tz_offset=-14400.0,
     ),
     database.PhotoFile(
         checksum="2aca4e78afbcebf2526ad8ac544d90b92991faae22499eec45831ef7be392391",
@@ -66,6 +73,7 @@ photofile_expected_results = [
         datetime="2018:08:01 19:28:36",
         timestamp=1533166116.0,
         file_size=506,
+        tz_offset=-14400.0,
     ),
 ]
 
@@ -79,6 +87,6 @@ def test_photofile_from_file(datafiles):
             pf.source_path = str(datafiles / rel_path)
             new_pf = database.PhotoFile.from_file(
                 pf.source_path,
-                tz_default=timezone(timedelta(days=-1, seconds=72000)),
+                tz_default=timezone(timedelta(seconds=pf.tz_offset)),
             )
             assert new_pf == pf

--- a/tests/integ_tests/test_photofile.py
+++ b/tests/integ_tests/test_photofile.py
@@ -12,7 +12,9 @@ ALL_IMG_DIRS = pytest.mark.datafiles(
 )
 photofile_expected_results = [
     database.PhotoFile(
-        checksum="d090ce7023b57925e7e94fc80372e3434fb1897e00b4452a25930dd1b83648fb",
+        checksum=bytes.fromhex(
+            "d090ce7023b57925e7e94fc80372e3434fb1897e00b4452a25930dd1b83648fb"
+        ),
         source_path="A/img1.jpg",
         datetime="2015:08:01 18:28:36.90",
         timestamp=1438468116.9,
@@ -20,7 +22,9 @@ photofile_expected_results = [
         tz_offset=-14400.0,
     ),
     database.PhotoFile(
-        checksum="3b39f47d51f63e54c76417ee6e04c34bd3ff5ac47696824426dca9e200f03666",
+        checksum=bytes.fromhex(
+            "3b39f47d51f63e54c76417ee6e04c34bd3ff5ac47696824426dca9e200f03666"
+        ),
         source_path="A/img2.jpg",
         datetime="2015:08:01 18:28:36.99",
         timestamp=1438450116.99,
@@ -28,7 +32,9 @@ photofile_expected_results = [
         tz_offset=3600.0,
     ),
     database.PhotoFile(
-        checksum="1e10df2e3abe4c810551525b6cb2eb805886de240e04cc7c13c58ae208cabfb9",
+        checksum=bytes.fromhex(
+            "1e10df2e3abe4c810551525b6cb2eb805886de240e04cc7c13c58ae208cabfb9"
+        ),
         source_path="A/img1.png",
         datetime="2015:08:01 18:28:36.90",
         timestamp=1438453716.9,
@@ -36,7 +42,9 @@ photofile_expected_results = [
         tz_offset=0.0,
     ),
     database.PhotoFile(
-        checksum="79ac4a89fb3d81ab1245b21b11ff7512495debca60f6abf9afbb1e1fbfe9d98c",
+        checksum=bytes.fromhex(
+            "79ac4a89fb3d81ab1245b21b11ff7512495debca60f6abf9afbb1e1fbfe9d98c"
+        ),
         source_path="A/img4.jpg",
         datetime="2018:08:01 20:28:36",
         timestamp=1533169716.0,
@@ -44,7 +52,9 @@ photofile_expected_results = [
         tz_offset=-14400.0,
     ),
     database.PhotoFile(
-        checksum="d090ce7023b57925e7e94fc80372e3434fb1897e00b4452a25930dd1b83648fb",
+        checksum=bytes.fromhex(
+            "d090ce7023b57925e7e94fc80372e3434fb1897e00b4452a25930dd1b83648fb"
+        ),
         source_path="B/img1.jpg",
         datetime="2015:08:01 18:28:36.90",
         timestamp=1438468116.9,
@@ -52,7 +62,9 @@ photofile_expected_results = [
         tz_offset=-14400.0,
     ),
     database.PhotoFile(
-        checksum="e9fec87008fd240309b81c997e7ec5491fee8da7eb1a76fc39b8fcafa76bb583",
+        checksum=bytes.fromhex(
+            "e9fec87008fd240309b81c997e7ec5491fee8da7eb1a76fc39b8fcafa76bb583"
+        ),
         source_path="B/img2.jpg",
         datetime="2015:08:01 18:28:36.99",
         timestamp=1438468116.99,
@@ -60,7 +72,9 @@ photofile_expected_results = [
         tz_offset=-14400.0,
     ),
     database.PhotoFile(
-        checksum="2b0f304f86655ebd04272cc5e7e886e400b79a53ecfdc789f75dd380cbcc8317",
+        checksum=bytes.fromhex(
+            "2b0f304f86655ebd04272cc5e7e886e400b79a53ecfdc789f75dd380cbcc8317"
+        ),
         source_path="B/img4.jpg",
         datetime="2018:08:01 20:28:36",
         timestamp=1533169716.0,
@@ -68,7 +82,9 @@ photofile_expected_results = [
         tz_offset=-14400.0,
     ),
     database.PhotoFile(
-        checksum="2aca4e78afbcebf2526ad8ac544d90b92991faae22499eec45831ef7be392391",
+        checksum=bytes.fromhex(
+            "2aca4e78afbcebf2526ad8ac544d90b92991faae22499eec45831ef7be392391"
+        ),
         source_path="C/img3.tiff",
         datetime="2018:08:01 19:28:36",
         timestamp=1533166116.0,

--- a/tests/integ_tests/test_photofile.py
+++ b/tests/integ_tests/test_photofile.py
@@ -12,84 +12,84 @@ ALL_IMG_DIRS = pytest.mark.datafiles(
 )
 photofile_expected_results = [
     database.PhotoFile(
-        checksum=bytes.fromhex(
+        chk=bytes.fromhex(
             "d090ce7023b57925e7e94fc80372e3434fb1897e00b4452a25930dd1b83648fb"
         ),
-        source_path="A/img1.jpg",
-        datetime="2015:08:01 18:28:36.90",
-        timestamp=1438468116.9,
-        file_size=771,
-        tz_offset=-14400.0,
+        src="A/img1.jpg",
+        dt="2015:08:01 18:28:36.90",
+        ts=1438468116.9,
+        fsz=771,
+        tzo=-14400.0,
     ),
     database.PhotoFile(
-        checksum=bytes.fromhex(
+        chk=bytes.fromhex(
             "3b39f47d51f63e54c76417ee6e04c34bd3ff5ac47696824426dca9e200f03666"
         ),
-        source_path="A/img2.jpg",
-        datetime="2015:08:01 18:28:36.99",
-        timestamp=1438450116.99,
-        file_size=771,
-        tz_offset=3600.0,
+        src="A/img2.jpg",
+        dt="2015:08:01 18:28:36.99",
+        ts=1438450116.99,
+        fsz=771,
+        tzo=3600.0,
     ),
     database.PhotoFile(
-        checksum=bytes.fromhex(
+        chk=bytes.fromhex(
             "1e10df2e3abe4c810551525b6cb2eb805886de240e04cc7c13c58ae208cabfb9"
         ),
-        source_path="A/img1.png",
-        datetime="2015:08:01 18:28:36.90",
-        timestamp=1438453716.9,
-        file_size=382,
-        tz_offset=0.0,
+        src="A/img1.png",
+        dt="2015:08:01 18:28:36.90",
+        ts=1438453716.9,
+        fsz=382,
+        tzo=0.0,
     ),
     database.PhotoFile(
-        checksum=bytes.fromhex(
+        chk=bytes.fromhex(
             "79ac4a89fb3d81ab1245b21b11ff7512495debca60f6abf9afbb1e1fbfe9d98c"
         ),
-        source_path="A/img4.jpg",
-        datetime="2018:08:01 20:28:36",
-        timestamp=1533169716.0,
-        file_size=759,
-        tz_offset=-14400.0,
+        src="A/img4.jpg",
+        dt="2018:08:01 20:28:36",
+        ts=1533169716.0,
+        fsz=759,
+        tzo=-14400.0,
     ),
     database.PhotoFile(
-        checksum=bytes.fromhex(
+        chk=bytes.fromhex(
             "d090ce7023b57925e7e94fc80372e3434fb1897e00b4452a25930dd1b83648fb"
         ),
-        source_path="B/img1.jpg",
-        datetime="2015:08:01 18:28:36.90",
-        timestamp=1438468116.9,
-        file_size=771,
-        tz_offset=-14400.0,
+        src="B/img1.jpg",
+        dt="2015:08:01 18:28:36.90",
+        ts=1438468116.9,
+        fsz=771,
+        tzo=-14400.0,
     ),
     database.PhotoFile(
-        checksum=bytes.fromhex(
+        chk=bytes.fromhex(
             "e9fec87008fd240309b81c997e7ec5491fee8da7eb1a76fc39b8fcafa76bb583"
         ),
-        source_path="B/img2.jpg",
-        datetime="2015:08:01 18:28:36.99",
-        timestamp=1438468116.99,
-        file_size=789,
-        tz_offset=-14400.0,
+        src="B/img2.jpg",
+        dt="2015:08:01 18:28:36.99",
+        ts=1438468116.99,
+        fsz=789,
+        tzo=-14400.0,
     ),
     database.PhotoFile(
-        checksum=bytes.fromhex(
+        chk=bytes.fromhex(
             "2b0f304f86655ebd04272cc5e7e886e400b79a53ecfdc789f75dd380cbcc8317"
         ),
-        source_path="B/img4.jpg",
-        datetime="2018:08:01 20:28:36",
-        timestamp=1533169716.0,
-        file_size=777,
-        tz_offset=-14400.0,
+        src="B/img4.jpg",
+        dt="2018:08:01 20:28:36",
+        ts=1533169716.0,
+        fsz=777,
+        tzo=-14400.0,
     ),
     database.PhotoFile(
-        checksum=bytes.fromhex(
+        chk=bytes.fromhex(
             "2aca4e78afbcebf2526ad8ac544d90b92991faae22499eec45831ef7be392391"
         ),
-        source_path="C/img3.tiff",
-        datetime="2018:08:01 19:28:36",
-        timestamp=1533166116.0,
-        file_size=506,
-        tz_offset=-14400.0,
+        src="C/img3.tiff",
+        dt="2018:08:01 19:28:36",
+        ts=1533166116.0,
+        fsz=506,
+        tzo=-14400.0,
     ),
 ]
 
@@ -99,10 +99,10 @@ def test_photofile_from_file(datafiles):
     with pyexiftool.ExifTool():
         for pf in photofile_expected_results:
             pf = database.PhotoFile.from_dict(pf.to_dict())
-            rel_path = pf.source_path
-            pf.source_path = str(datafiles / rel_path)
+            rel_path = pf.src
+            pf.src = str(datafiles / rel_path)
             new_pf = database.PhotoFile.from_file(
-                pf.source_path,
-                tz_default=timezone(timedelta(seconds=pf.tz_offset)),
+                pf.src,
+                tz_default=timezone(timedelta(seconds=pf.tzo)),
             )
             assert new_pf == pf

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -82,23 +82,6 @@ def test_cli_main(monkeypatch, capsys):
     assert captured.out.strip() == f"photomanager {version}"
     assert captured.err == ""
 
-    monkeypatch.setattr(sys, "argv", ["photomanager", "--version"])
-    with pytest.raises(SystemExit) as exit_type:
-        __main__.main()
-    captured = capsys.readouterr()
-    assert exit_type.value.code == 0
-    assert captured.out.strip() == f"photomanager {version}"
-    assert captured.err == ""
-
-    monkeypatch.setattr(cli, "__name__", "__main__")
-    monkeypatch.setattr(sys, "argv", ["photomanager", "--version"])
-    with pytest.raises(SystemExit) as exit_type:
-        cli._init()
-    captured = capsys.readouterr()
-    assert exit_type.value.code == 0
-    assert captured.out.strip() == f"photomanager {version}"
-    assert captured.err == ""
-
 
 def test_cli_exit_codes(monkeypatch):
     monkeypatch.setattr(cli, "__name__", "__main__")

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -110,7 +110,7 @@ def test_cli_create(tmpdir, caplog):
         d = json.loads(s)
         assert d["photo_db"] == {}
         assert d["version"] == database.Database.VERSION
-        assert d["hash_algorithm"] == database.DEFAULT_HASH_ALGO
+        assert d["hash_algorithm"] == database.DEFAULT_HASH_ALGO.value
         check_dir_empty(fs)
 
 

--- a/tests/unit_tests/test_database.py
+++ b/tests/unit_tests/test_database.py
@@ -13,36 +13,36 @@ from photomanager.hasher import HashAlgorithm
 def test_photofile_to_dict():
     """ """
     assert PhotoFile(
-        checksum=b"deadbeef",
-        source_path="/a/b/c.jpg",
-        datetime="2015:08:27 04:09:36.50",
-        timestamp=1440662976.5,
-        file_size=1024,
-        store_path="/d/e/f.jpg",
-        priority=11,
-        tz_offset=-14400,
+        chk=b"deadbeef",
+        src="/a/b/c.jpg",
+        dt="2015:08:27 04:09:36.50",
+        ts=1440662976.5,
+        fsz=1024,
+        sto="/d/e/f.jpg",
+        prio=11,
+        tzo=-14400,
     ).to_dict() == {
-        "checksum": b"deadbeef",
-        "source_path": "/a/b/c.jpg",
-        "datetime": "2015:08:27 04:09:36.50",
-        "timestamp": 1440662976.5,
-        "file_size": 1024,
-        "store_path": "/d/e/f.jpg",
-        "priority": 11,
-        "tz_offset": -14400,
+        "chk": b"deadbeef",
+        "src": "/a/b/c.jpg",
+        "dt": "2015:08:27 04:09:36.50",
+        "ts": 1440662976.5,
+        "fsz": 1024,
+        "sto": "/d/e/f.jpg",
+        "prio": 11,
+        "tzo": -14400,
     }
 
 
 def test_photofile_to_json():
     pf = PhotoFile(
-        checksum=b"\xde\xad\xbe\xef",
-        source_path="/a/b/c.jpg",
-        datetime="2015:08:27 04:09:36.50",
-        timestamp=1440662976.5,
-        file_size=1024,
-        store_path="/d/e/f.jpg",
-        priority=11,
-        tz_offset=-14400,
+        chk=b"\xde\xad\xbe\xef",
+        src="/a/b/c.jpg",
+        dt="2015:08:27 04:09:36.50",
+        ts=1440662976.5,
+        fsz=1024,
+        sto="/d/e/f.jpg",
+        prio=11,
+        tzo=-14400,
     )
     print(pf)
     print(pf.__getattribute__("__dict__"))
@@ -60,60 +60,60 @@ def test_photofile_to_json():
 
 def test_photofile_eq():
     assert PhotoFile(
-        checksum=b"\xde\xad\xbe\xef",
-        source_path="/a/b/c.jpg",
-        datetime="2015:08:27 04:09:36.50",
-        timestamp=1440662976.5,
-        file_size=1024,
-        store_path="/d/e/f.jpg",
-        priority=11,
+        chk=b"\xde\xad\xbe\xef",
+        src="/a/b/c.jpg",
+        dt="2015:08:27 04:09:36.50",
+        ts=1440662976.5,
+        fsz=1024,
+        sto="/d/e/f.jpg",
+        prio=11,
     ) == PhotoFile(
-        checksum=b"\xde\xad\xbe\xef",
-        source_path="/a/b/c.jpg",
-        datetime="2015:08:27 04:09:36.50",
-        timestamp=1440662976.5,
-        file_size=1024,
-        store_path="/d/e/f.jpg",
-        priority=11,
+        chk=b"\xde\xad\xbe\xef",
+        src="/a/b/c.jpg",
+        dt="2015:08:27 04:09:36.50",
+        ts=1440662976.5,
+        fsz=1024,
+        sto="/d/e/f.jpg",
+        prio=11,
     )
 
 
 def test_photofile_neq():
     pf1 = PhotoFile(
-        checksum=b"deadbeef",
-        source_path="/a/b/c.jpg",
-        datetime="2015:08:27 04:09:36.50",
-        timestamp=1440662976.5,
-        file_size=1024,
-        store_path="/d/e/f.jpg",
-        priority=11,
+        chk=b"deadbeef",
+        src="/a/b/c.jpg",
+        dt="2015:08:27 04:09:36.50",
+        ts=1440662976.5,
+        fsz=1024,
+        sto="/d/e/f.jpg",
+        prio=11,
     )
     assert pf1 != PhotoFile(
-        checksum=b"deadfeed",
-        source_path="/a/b/c.jpg",
-        datetime="2015:08:27 04:09:36.50",
-        timestamp=1440662976.5,
-        file_size=1024,
-        store_path="/d/e/f.jpg",
-        priority=11,
+        chk=b"deadfeed",
+        src="/a/b/c.jpg",
+        dt="2015:08:27 04:09:36.50",
+        ts=1440662976.5,
+        fsz=1024,
+        sto="/d/e/f.jpg",
+        prio=11,
     )
     assert pf1 != PhotoFile(
-        checksum=b"deadbeef",
-        source_path="/a/b/d.jpg",
-        datetime="2015:08:27 04:09:36.50",
-        timestamp=1440662976.5,
-        file_size=1024,
-        store_path="/d/e/f.jpg",
-        priority=11,
+        chk=b"deadbeef",
+        src="/a/b/d.jpg",
+        dt="2015:08:27 04:09:36.50",
+        ts=1440662976.5,
+        fsz=1024,
+        sto="/d/e/f.jpg",
+        prio=11,
     )
     assert pf1 != PhotoFile(
-        checksum=b"deadbeef",
-        source_path="/a/b/d.jpg",
-        datetime="2015:08:27 04:09:36.50",
-        timestamp=1440662976.0,
-        file_size=1024,
-        store_path="/d/e/f.jpg",
-        priority=11,
+        chk=b"deadbeef",
+        src="/a/b/d.jpg",
+        dt="2015:08:27 04:09:36.50",
+        ts=1440662976.0,
+        fsz=1024,
+        sto="/d/e/f.jpg",
+        prio=11,
     )
 
 
@@ -176,25 +176,25 @@ def test_database_load_version_1():
         "d239210f00534b76a2b215e073f75832": [
             PhotoFile.from_dict(
                 {
-                    "checksum": bytes.fromhex("deadbeef"),
-                    "source_path": "/a/b/c.jpg",
-                    "datetime": "2015:08:27 04:09:36.50",
-                    "timestamp": 1440662976.5,
-                    "file_size": 1024,
-                    "store_path": "/d/e/f.jpg",
-                    "priority": 11,
+                    "chk": bytes.fromhex("deadbeef"),
+                    "src": "/a/b/c.jpg",
+                    "dt": "2015:08:27 04:09:36.50",
+                    "ts": 1440662976.5,
+                    "fsz": 1024,
+                    "sto": "/d/e/f.jpg",
+                    "prio": 11,
                 }
             ),
             PhotoFile.from_dict(
                 {
-                    "checksum": bytes.fromhex("deadbeef"),
-                    "source_path": "/g/b/c.jpg",
-                    "datetime": "2015:08:27 04:09:36.50",
-                    "timestamp": 1440662976.5,
-                    "file_size": 1024,
-                    "store_path": "",
-                    "priority": 20,
-                    "tz_offset": -14400,
+                    "chk": bytes.fromhex("deadbeef"),
+                    "src": "/g/b/c.jpg",
+                    "dt": "2015:08:27 04:09:36.50",
+                    "ts": 1440662976.5,
+                    "fsz": 1024,
+                    "sto": "",
+                    "prio": 20,
+                    "tzo": -14400,
                 }
             ),
         ]
@@ -277,7 +277,7 @@ def test_database_load_version_3():
 "version": 3,
 "hash_algorithm": "sha256",
 "photo_db": {
-    "d239210f00534b76a2b215e073f75832": [
+    "QKEsTn2X": [
         {
             "chk": "deadbeef",
             "src": "/a/b/c.jpg",
@@ -314,28 +314,28 @@ def test_database_load_version_3():
     assert db.db["timezone_default"] == "local"
     assert db.timezone_default is None
     photo_db_expected = {
-        "d239210f00534b76a2b215e073f75832": [
+        "QKEsTn2X": [
             PhotoFile.from_json_dict(
                 {
-                    "checksum": "deadbeef",
-                    "source_path": "/a/b/c.jpg",
-                    "datetime": "2015:08:27 04:09:36.50",
-                    "timestamp": 1440662976.5,
-                    "file_size": 1024,
-                    "store_path": "/d/e/f.jpg",
-                    "priority": 11,
+                    "chk": "deadbeef",
+                    "src": "/a/b/c.jpg",
+                    "dt": "2015:08:27 04:09:36.50",
+                    "ts": 1440662976.5,
+                    "fsz": 1024,
+                    "sto": "/d/e/f.jpg",
+                    "prio": 11,
                 }
             ),
             PhotoFile.from_json_dict(
                 {
-                    "checksum": "deadbeef",
-                    "source_path": "/g/b/c.jpg",
-                    "datetime": "2015:08:27 04:09:36.50",
-                    "timestamp": 1440662976.5,
-                    "file_size": 1024,
-                    "store_path": "",
-                    "priority": 20,
-                    "tz_offset": -14400,
+                    "chk": "deadbeef",
+                    "src": "/g/b/c.jpg",
+                    "dt": "2015:08:27 04:09:36.50",
+                    "ts": 1440662976.5,
+                    "fsz": 1024,
+                    "sto": "",
+                    "prio": 20,
+                    "tzo": -14400,
                 }
             ),
         ]
@@ -401,12 +401,15 @@ def test_database_save(tmpdir, caplog):
     db = Database.from_json(example_database_json_data)
     db.to_file(tmpdir / "test.json")
     db2 = db.from_file(tmpdir / "test.json")
+    print(db.db, db2.db, sep="\n")
     assert db == db2
     db.to_file(tmpdir / "test.json.gz")
     db2 = db.from_file(tmpdir / "test.json.gz")
+    print(db2.db)
     assert db == db2
     db.to_file(tmpdir / "test.json.zst")
     db2 = db.from_file(tmpdir / "test.json.zst")
+    print(db2.db)
     assert db == db2
 
 
@@ -478,41 +481,41 @@ def test_database_add_photo_sort(caplog):
     db = Database.from_json(example_database_json_data)
     uid = db.add_photo(
         PhotoFile(
-            checksum=bytes.fromhex("deadbeef"),
-            source_path="/x/y/c.jpg",
-            datetime="2015:08:27 04:09:36.50",
-            timestamp=1440662976.5,
-            file_size=1024,
-            store_path="",
-            priority=20,
+            chk=bytes.fromhex("deadbeef"),
+            src="/x/y/c.jpg",
+            dt="2015:08:27 04:09:36.50",
+            ts=1440662976.5,
+            fsz=1024,
+            sto="",
+            prio=20,
         ),
         uid=None,
     )
     db.add_photo(
         PhotoFile(
-            checksum=bytes.fromhex("deadbeef"),
-            source_path="/z/y/c.jpg",
-            datetime="2015:08:27 04:09:36.50",
-            timestamp=1440662976.5,
-            file_size=1024,
-            store_path="",
-            priority=11,
+            chk=bytes.fromhex("deadbeef"),
+            src="/z/y/c.jpg",
+            dt="2015:08:27 04:09:36.50",
+            ts=1440662976.5,
+            fsz=1024,
+            sto="",
+            prio=11,
         ),
         uid=None,
     )
     db.add_photo(
         PhotoFile(
-            checksum=bytes.fromhex("deadbeef"),
-            source_path="/0/1/c.jpg",
-            datetime="2015:08:27 04:09:36.50",
-            timestamp=1440662976.5,
-            file_size=1024,
-            store_path="",
-            priority=10,
+            chk=bytes.fromhex("deadbeef"),
+            src="/0/1/c.jpg",
+            dt="2015:08:27 04:09:36.50",
+            ts=1440662976.5,
+            fsz=1024,
+            sto="",
+            prio=10,
         ),
         uid=None,
     )
-    assert list(p.source_path for p in db.photo_db[uid]) == [
+    assert list(p.src for p in db.photo_db[uid]) == [
         "/0/1/c.jpg",
         "/a/b/c.jpg",
         "/z/y/c.jpg",
@@ -560,13 +563,13 @@ def test_database_find_photo_ambiguous(caplog):
     db = Database.from_json(example_database_json_data2)
     uid = db.find_photo(
         PhotoFile(
-            checksum=b"not_a_match",
-            source_path="/x/y/c.jpg",
-            datetime="2015:08:27 04:09:36.50",
-            timestamp=1440662976.5,
-            file_size=1024,
-            store_path="",
-            priority=10,
+            chk=b"not_a_match",
+            src="/x/y/c.jpg",
+            dt="2015:08:27 04:09:36.50",
+            ts=1440662976.5,
+            fsz=1024,
+            sto="",
+            prio=10,
         )
     )
     print([(r.levelname, r) for r in caplog.records])
@@ -587,13 +590,13 @@ def test_database_add_photo_wrong_uid(caplog):
     db = Database.from_json(example_database_json_data2)
     uid = db.add_photo(
         PhotoFile(
-            checksum=bytes.fromhex("deadbeef"),
-            source_path="/x/y/c.jpg",
-            datetime="2015:08:27 04:09:36.50",
-            timestamp=1440662976.5,
-            file_size=1024,
-            store_path="",
-            priority=10,
+            chk=bytes.fromhex("deadbeef"),
+            src="/x/y/c.jpg",
+            dt="2015:08:27 04:09:36.50",
+            ts=1440662976.5,
+            fsz=1024,
+            sto="",
+            prio=10,
         ),
         uid="uid2",
     )
@@ -611,13 +614,13 @@ def test_database_add_photo_already_present(caplog):
     db = Database.from_json(example_database_json_data2)
     uid = db.add_photo(
         PhotoFile(
-            checksum=bytes.fromhex("deadbeef"),
-            source_path="/a/b/c.jpg",
-            datetime="2015:08:27 04:09:36.50",
-            timestamp=1440662976.5,
-            file_size=1024,
-            store_path="",
-            priority=10,
+            chk=bytes.fromhex("deadbeef"),
+            src="/a/b/c.jpg",
+            dt="2015:08:27 04:09:36.50",
+            ts=1440662976.5,
+            fsz=1024,
+            sto="",
+            prio=10,
         ),
         uid="uid1",
     )
@@ -635,13 +638,13 @@ def test_database_add_photo_same_source_new_checksum(caplog):
     db = Database.from_json(example_database_json_data2)
     uid = db.add_photo(
         PhotoFile(
-            checksum=b"not_a_match",
-            source_path="/a/b/c.jpg",
-            datetime="2015:08:27 04:09:36.50",
-            timestamp=1440662976.5,
-            file_size=1024,
-            store_path="",
-            priority=10,
+            chk=b"not_a_match",
+            src="/a/b/c.jpg",
+            dt="2015:08:27 04:09:36.50",
+            ts=1440662976.5,
+            fsz=1024,
+            sto="",
+            prio=10,
         ),
         uid="uid1",
     )

--- a/tests/unit_tests/test_database.py
+++ b/tests/unit_tests/test_database.py
@@ -47,7 +47,7 @@ def test_photofile_to_json():
     print(pf)
     print(pf.__getattribute__("__dict__"))
     assert pf.__dict__ == {
-        "chk": "3q2+7w==",
+        "chk": "deadbeef",
         "src": "/a/b/c.jpg",
         "dt": "2015:08:27 04:09:36.50",
         "ts": 1440662976.5,
@@ -263,7 +263,6 @@ def test_database_init_update_version_1():
             b'"' + k.encode() + b'"',
             b'"' + v.encode() + b'"',
         )
-    new_json_data = new_json_data.replace(b'"chk": "deadbeef"', b'"chk": "3q2+7w=="')
     db = Database.from_json(json_data)
     print(db.db)
     assert db.db["timezone_default"] == "-0400"

--- a/tests/unit_tests/test_datetime.py
+++ b/tests/unit_tests/test_datetime.py
@@ -1,7 +1,8 @@
 import datetime
 import pytest
 from photomanager.pyexiftool import best_datetime
-from photomanager.database import Database, datetime_str_to_object
+from photomanager.database import Database
+from photomanager.photofile import datetime_str_to_object
 
 
 best_datetime_expected_results = [

--- a/tests/unit_tests/test_datetime.py
+++ b/tests/unit_tests/test_datetime.py
@@ -189,13 +189,7 @@ datetime_ts_expected_results = [
     {
         "timestamp_str": "2015:08:27 04:09:36.50-0400",
         "datetime_obj": datetime.datetime(
-            2015,
-            8,
-            27,
-            4,
-            9,
-            36,
-            500000,
+            *(2015, 8, 27, 4, 9, 36, 500000),
             tzinfo=datetime.timezone(datetime.timedelta(days=-1, seconds=72000)),
         ),
         "timestamp": 1440662976.5,
@@ -203,11 +197,7 @@ datetime_ts_expected_results = [
     {
         "timestamp_str": "2015:08:27 04:09-0300",
         "datetime_obj": datetime.datetime(
-            2015,
-            8,
-            27,
-            4,
-            9,
+            *(2015, 8, 27, 4, 9),
             tzinfo=datetime.timezone(datetime.timedelta(days=-1, seconds=75600)),
         ),
         "timestamp": 1440659340.0,

--- a/tests/unit_tests/test_hasher.py
+++ b/tests/unit_tests/test_hasher.py
@@ -8,29 +8,38 @@ from photomanager.hasher import (
     AsyncFileHasher,
     HasherException,
     FileHasherJob,
+    HashAlgorithm,
 )
 from . import AsyncNopProcess
 
 checksum_expected_results = [
     {
-        "algorithm": "blake2b-256",
+        "algorithm": HashAlgorithm.BLAKE2B_256,
         "bytes": b"",
-        "checksum": "0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8",
+        "checksum": bytes.fromhex(
+            "0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8"
+        ),
     },
     {
-        "algorithm": "blake2b-256",
+        "algorithm": HashAlgorithm.BLAKE2B_256,
         "bytes": b"\xff\xd8\xff\xe0",
-        "checksum": "7d13007a8afed521cfc13306cbd6747bbc59556e3ca9514c8d94f900fbb56230",
+        "checksum": bytes.fromhex(
+            "7d13007a8afed521cfc13306cbd6747bbc59556e3ca9514c8d94f900fbb56230"
+        ),
     },
     {
-        "algorithm": "sha256",
+        "algorithm": HashAlgorithm.SHA256,
         "bytes": b"",
-        "checksum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "checksum": bytes.fromhex(
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        ),
     },
     {
-        "algorithm": "sha256",
+        "algorithm": HashAlgorithm.SHA256,
         "bytes": b"\xff\xd8\xff\xe0",
-        "checksum": "ba4f25bf16ba4be6bc7d3276fafeb67f9eb3c5df042bc3a405e1af15b921eed7",
+        "checksum": bytes.fromhex(
+            "ba4f25bf16ba4be6bc7d3276fafeb67f9eb3c5df042bc3a405e1af15b921eed7"
+        ),
     },
 ]
 
@@ -52,11 +61,13 @@ def test_file_checksum_path(checksum, tmpdir):
     )
 
 
+# noinspection PyTypeChecker
 def test_file_checksum_bad_algorithm():
     with pytest.raises(HasherException):
         file_checksum("asdf.txt", algorithm="md5")
 
 
+# noinspection PyTypeChecker
 def test_async_file_hasher_bad_algorithm():
     with pytest.raises(HasherException):
         AsyncFileHasher(algorithm="md5")
@@ -66,12 +77,12 @@ def test_async_file_hasher_img(monkeypatch, caplog):
     async def nop_cse(*_, **__):
         loop = asyncio.events.get_event_loop()
         loop.set_debug(True)
-        return AsyncNopProcess(b"ba4f25bf16ba4be6bc7d3276fafeb img1.jpg\n", b"")
+        return AsyncNopProcess(b"ba4f25bf16ba4be6bc7d3276fafeba img1.jpg\n", b"")
 
     monkeypatch.setattr(subprocess_async, "create_subprocess_exec", nop_cse)
     caplog.set_level(logging.DEBUG)
     checksum_cache = AsyncFileHasher(
-        algorithm="blake2b-256",
+        algorithm=HashAlgorithm.BLAKE2B_256,
         use_async=True,
         batch_size=1,
     ).check_files(["img1.jpg"], pbar_unit="it")
@@ -80,7 +91,7 @@ def test_async_file_hasher_img(monkeypatch, caplog):
     assert not any(record.levelname == "WARNING" for record in caplog.records)
     assert len(checksum_cache) == 1
     assert "img1.jpg" in checksum_cache
-    assert checksum_cache["img1.jpg"] == "ba4f25bf16ba4be6bc7d3276fafeb"
+    assert checksum_cache["img1.jpg"] == bytes.fromhex("ba4f25bf16ba4be6bc7d3276fafeba")
 
 
 def test_async_file_hasher_empty(monkeypatch, caplog):
@@ -92,7 +103,7 @@ def test_async_file_hasher_empty(monkeypatch, caplog):
     monkeypatch.setattr(subprocess_async, "create_subprocess_exec", nop_cse)
     caplog.set_level(logging.DEBUG)
     checksum_cache = AsyncFileHasher(
-        algorithm="blake2b-256",
+        algorithm=HashAlgorithm.BLAKE2B_256,
         use_async=True,
         batch_size=10,
     ).check_files(["asdf.bin"], pbar_unit="it")
@@ -111,7 +122,7 @@ def test_async_file_hasher_unicode_error(monkeypatch, caplog):
     monkeypatch.setattr(subprocess_async, "create_subprocess_exec", nop_cse)
     caplog.set_level(logging.DEBUG)
     checksum_cache = AsyncFileHasher(
-        algorithm="blake2b-256",
+        algorithm=HashAlgorithm.BLAKE2B_256,
         use_async=True,
         batch_size=10,
     ).check_files(["asdf.bin"], pbar_unit="it")
@@ -130,7 +141,7 @@ def test_async_file_hasher_interrupt(monkeypatch):
 
     monkeypatch.setattr(subprocess_async, "create_subprocess_exec", nop_cse)
     hasher = AsyncFileHasher(
-        algorithm="blake2b-256",
+        algorithm=HashAlgorithm.BLAKE2B_256,
         use_async=True,
         batch_size=10,
     )

--- a/tests/unit_tests/test_photofile.py
+++ b/tests/unit_tests/test_photofile.py
@@ -9,14 +9,14 @@ def test_tz_offset_local_datetime(offset):
     PhotoFile.local_datetime returns a datetime for UTC timestamp with tz_offset
     """
     pf = PhotoFile(
-        checksum=bytes.fromhex(
+        chk=bytes.fromhex(
             "d090ce7023b57925e7e94fc80372e3434fb1897e00b4452a25930dd1b83648fb"
         ),
-        source_path="A/img1.jpg",
-        datetime="N/A",
-        timestamp=1438468116.9,
-        file_size=771,
-        tz_offset=offset,
+        src="A/img1.jpg",
+        dt="N/A",
+        ts=1438468116.9,
+        fsz=771,
+        tzo=offset,
     )
     print(repr(pf.local_datetime))
     assert (
@@ -34,13 +34,13 @@ def test_local_time_string_none():
     as an offset to timestamp.
     """
     pf = PhotoFile(
-        checksum=bytes.fromhex(
+        chk=bytes.fromhex(
             "d090ce7023b57925e7e94fc80372e3434fb1897e00b4452a25930dd1b83648fb"
         ),
-        source_path="A/img1.jpg",
-        datetime="N/A",
-        timestamp=1438468116.9,
-        file_size=771,
+        src="A/img1.jpg",
+        dt="N/A",
+        ts=1438468116.9,
+        fsz=771,
     )
     print(repr(pf.local_datetime))
     local_tzinfo = datetime.now().astimezone().tzinfo

--- a/tests/unit_tests/test_photofile.py
+++ b/tests/unit_tests/test_photofile.py
@@ -9,7 +9,9 @@ def test_tz_offset_local_datetime(offset):
     PhotoFile.local_datetime returns a datetime for UTC timestamp with tz_offset
     """
     pf = PhotoFile(
-        checksum="d090ce7023b57925e7e94fc80372e3434fb1897e00b4452a25930dd1b83648fb",
+        checksum=bytes.fromhex(
+            "d090ce7023b57925e7e94fc80372e3434fb1897e00b4452a25930dd1b83648fb"
+        ),
         source_path="A/img1.jpg",
         datetime="N/A",
         timestamp=1438468116.9,
@@ -32,7 +34,9 @@ def test_local_time_string_none():
     as an offset to timestamp.
     """
     pf = PhotoFile(
-        checksum="d090ce7023b57925e7e94fc80372e3434fb1897e00b4452a25930dd1b83648fb",
+        checksum=bytes.fromhex(
+            "d090ce7023b57925e7e94fc80372e3434fb1897e00b4452a25930dd1b83648fb"
+        ),
         source_path="A/img1.jpg",
         datetime="N/A",
         timestamp=1438468116.9,

--- a/tests/unit_tests/test_photofile.py
+++ b/tests/unit_tests/test_photofile.py
@@ -1,0 +1,49 @@
+import pytest
+from datetime import datetime, timezone, timedelta
+from photomanager.database import PhotoFile
+
+
+@pytest.mark.parametrize("offset", [-14400, -3600.0, 0, 10, 36000])
+def test_tz_offset_local_datetime(offset):
+    """
+    PhotoFile.local_datetime returns a datetime for UTC timestamp with tz_offset
+    """
+    pf = PhotoFile(
+        checksum="d090ce7023b57925e7e94fc80372e3434fb1897e00b4452a25930dd1b83648fb",
+        source_path="A/img1.jpg",
+        datetime="N/A",
+        timestamp=1438468116.9,
+        file_size=771,
+        tz_offset=offset,
+    )
+    print(repr(pf.local_datetime))
+    assert (
+        pf.local_datetime
+        == datetime(
+            *(2015, 8, 1, 22, 28, 36, 900000),
+            tzinfo=timezone.utc,
+        ).astimezone(timezone(timedelta(seconds=offset)))
+    )
+
+
+def test_local_time_string_none():
+    """
+    If no timezone is specified, PhotoFile uses the local time zone
+    as an offset to timestamp.
+    """
+    pf = PhotoFile(
+        checksum="d090ce7023b57925e7e94fc80372e3434fb1897e00b4452a25930dd1b83648fb",
+        source_path="A/img1.jpg",
+        datetime="N/A",
+        timestamp=1438468116.9,
+        file_size=771,
+    )
+    print(repr(pf.local_datetime))
+    local_tzinfo = datetime.now().astimezone().tzinfo
+    assert (
+        pf.local_datetime
+        == datetime(
+            *(2015, 8, 1, 22, 28, 36, 900000),
+            tzinfo=timezone.utc,
+        ).astimezone(local_tzinfo)
+    )


### PR DESCRIPTION
Adds a local timezone offset for each PhotoFile.
Stores checksums as bytes, reduces the size of uid strings to 8 characters, and shortens PhotoFile attribute names.