### PR TITLE
Add index --dump option

### DIFF
--- a/src/photomanager/actions/actions.py
+++ b/src/photomanager/actions/actions.py
@@ -65,6 +65,7 @@ def index(
         num_merged_photos=num_merged_photos,
         num_skipped_photos=num_skipped_photos,
         num_error_photos=num_error_photos,
+        photos=photos,
     )
 
 

--- a/src/photomanager/actions/fileops.py
+++ b/src/photomanager/actions/fileops.py
@@ -134,7 +134,7 @@ def index_photos(
     exiftool.start()
     for current_file in tqdm(files):
         if logger.isEnabledFor(logging.DEBUG):
-            tqdm.write(f"Indexing {current_file}")
+            tqdm.write(f"Indexing {current_file}", file=sys.stderr)
         try:
             pf = PhotoFile.from_file_cached(
                 current_file,
@@ -189,7 +189,8 @@ def copy_photos(
         if logger.isEnabledFor(logging.DEBUG):
             tqdm.write(
                 f"{'Would copy' if dry_run else 'Copying'}: {photo.src} "
-                f"to {abs_store_path}"
+                f"to {abs_store_path}",
+                file=sys.stderr,
             )
         try:
             if not dry_run:
@@ -234,7 +235,8 @@ def remove_photos(
         if abs_store_path.exists():
             if logger.isEnabledFor(logging.DEBUG):
                 tqdm.write(
-                    f"{'Would remove' if dry_run else 'Removing'}: {abs_store_path}"
+                    f"{'Would remove' if dry_run else 'Removing'}: {abs_store_path}",
+                    file=sys.stderr,
                 )
             if not dry_run:
                 remove(abs_store_path)
@@ -242,7 +244,7 @@ def remove_photos(
             num_removed_photos += 1
         else:
             if logger.isEnabledFor(logging.DEBUG):
-                tqdm.write(f"Missing photo: {abs_store_path}")
+                tqdm.write(f"Missing photo: {abs_store_path}", file=sys.stderr)
             num_missing_photos += 1
     return num_removed_photos, num_missing_photos
 

--- a/src/photomanager/actions/fileops.py
+++ b/src/photomanager/actions/fileops.py
@@ -67,8 +67,11 @@ def list_files(
     elif file:
         files[Path(file).expanduser().resolve()] = None
     for path in paths:
-        for p in path.glob("**/*.*"):
-            files[p] = None
+        if path.is_file():
+            files[path] = None
+        else:
+            for p in path.glob("**/*.*"):
+                files[p] = None
 
     exclude_files = {Path(f).expanduser().resolve() for f in exclude_files}
     filtered_files = {}

--- a/src/photomanager/database.py
+++ b/src/photomanager/database.py
@@ -62,7 +62,8 @@ def tz_str_to_tzinfo(tz: str):
     try:
         return datetime.strptime(tz, "%z").tzinfo
     except ValueError:
-        pass
+        logger = logging.getLogger(__name__)
+        logger.error(f"Could not parse timezone string: {tz}")
 
 
 class DatabaseException(PhotoManagerBaseException):

--- a/tests/integ_tests/test_photofile.py
+++ b/tests/integ_tests/test_photofile.py
@@ -13,8 +13,8 @@ ALL_IMG_DIRS = pytest.mark.datafiles(
     FIXTURE_DIR / "C",
     keep_top_dir=True,
 )
-photofile_expected_results = [
-    PhotoFile(
+PHOTOFILE_EXPECTED_RESULTS = {
+    "A/img1.jpg": PhotoFile(
         chk="d090ce7023b57925e7e94fc80372e3434fb1897e00b4452a25930dd1b83648fb",
         src="A/img1.jpg",
         dt="2015:08:01 18:28:36.90",
@@ -22,7 +22,7 @@ photofile_expected_results = [
         fsz=771,
         tzo=-14400.0,
     ),
-    PhotoFile(
+    "A/img2.jpg": PhotoFile(
         chk="3b39f47d51f63e54c76417ee6e04c34bd3ff5ac47696824426dca9e200f03666",
         src="A/img2.jpg",
         dt="2015:08:01 18:28:36.99",
@@ -30,7 +30,7 @@ photofile_expected_results = [
         fsz=771,
         tzo=3600.0,
     ),
-    PhotoFile(
+    "A/img1.png": PhotoFile(
         chk="1e10df2e3abe4c810551525b6cb2eb805886de240e04cc7c13c58ae208cabfb9",
         src="A/img1.png",
         dt="2015:08:01 18:28:36.90",
@@ -38,7 +38,7 @@ photofile_expected_results = [
         fsz=382,
         tzo=0.0,
     ),
-    PhotoFile(
+    "A/img4.jpg": PhotoFile(
         chk="79ac4a89fb3d81ab1245b21b11ff7512495debca60f6abf9afbb1e1fbfe9d98c",
         src="A/img4.jpg",
         dt="2018:08:01 20:28:36",
@@ -46,7 +46,7 @@ photofile_expected_results = [
         fsz=759,
         tzo=-14400.0,
     ),
-    PhotoFile(
+    "B/img1.jpg": PhotoFile(
         chk="d090ce7023b57925e7e94fc80372e3434fb1897e00b4452a25930dd1b83648fb",
         src="B/img1.jpg",
         dt="2015:08:01 18:28:36.90",
@@ -54,7 +54,7 @@ photofile_expected_results = [
         fsz=771,
         tzo=-14400.0,
     ),
-    PhotoFile(
+    "B/img2.jpg": PhotoFile(
         chk="e9fec87008fd240309b81c997e7ec5491fee8da7eb1a76fc39b8fcafa76bb583",
         src="B/img2.jpg",
         dt="2015:08:01 18:28:36.99",
@@ -62,7 +62,7 @@ photofile_expected_results = [
         fsz=789,
         tzo=-14400.0,
     ),
-    PhotoFile(
+    "B/img4.jpg": PhotoFile(
         chk="2b0f304f86655ebd04272cc5e7e886e400b79a53ecfdc789f75dd380cbcc8317",
         src="B/img4.jpg",
         dt="2018:08:01 20:28:36",
@@ -70,7 +70,7 @@ photofile_expected_results = [
         fsz=777,
         tzo=-14400.0,
     ),
-    PhotoFile(
+    "C/img3.tiff": PhotoFile(
         chk="2aca4e78afbcebf2526ad8ac544d90b92991faae22499eec45831ef7be392391",
         src="C/img3.tiff",
         dt="2018:08:01 19:28:36",
@@ -78,13 +78,13 @@ photofile_expected_results = [
         fsz=506,
         tzo=-14400.0,
     ),
-]
+}
 
 
 @ALL_IMG_DIRS
 def test_photofile_from_file(datafiles):
     with ExifTool():
-        for pf in photofile_expected_results:
+        for pf in PHOTOFILE_EXPECTED_RESULTS.values():
             pf = PhotoFile.from_dict(pf.to_dict())
             rel_path = pf.src
             pf.src = str(datafiles / rel_path)

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -126,9 +126,9 @@ def test_cli_index_nothing(tmpdir, caplog):
         check_dir_empty(fs)
 
 
-def test_cli_index_collect_no_db(tmpdir, caplog):
+def test_cli_create_collect_no_db(tmpdir, caplog):
     """
-    If index is run with no db argument, db is created at DEFAULT_DB
+    If create and is run with no db argument, db is created at DEFAULT_DB
     """
     caplog.set_level(logging.DEBUG)
     CliRunner.isolated_filesystem(tmpdir)
@@ -140,10 +140,7 @@ def test_cli_index_collect_no_db(tmpdir, caplog):
         result = runner.invoke(
             cast(Group, cli.main),
             [
-                "index",
-                "--priority",
-                "10",
-                str(tmpdir),
+                "create",
             ],
         )
         print("\nINDEX no-db")
@@ -278,6 +275,9 @@ def test_cli_import_no_changes(tmpdir, caplog):
 
 
 def test_cli_collect_no_db(tmpdir, caplog):
+    """
+    collect must be given a database to collect to
+    """
     caplog.set_level(logging.DEBUG)
     CliRunner.isolated_filesystem(tmpdir)
     runner = CliRunner()
@@ -298,6 +298,9 @@ def test_cli_collect_no_db(tmpdir, caplog):
 
 
 def test_cli_verify_wrong_storage_type(tmpdir, caplog):
+    """
+    verify does not accept a nonexistent storage-type
+    """
     caplog.set_level(logging.DEBUG)
     CliRunner.isolated_filesystem(tmpdir)
     runner = CliRunner()
@@ -316,6 +319,9 @@ def test_cli_verify_wrong_storage_type(tmpdir, caplog):
 
 
 def test_cli_verify_random_sample(tmpdir, caplog):
+    """
+    verify random-fraction checks a fraction of the database
+    """
     caplog.set_level(logging.DEBUG)
     CliRunner.isolated_filesystem(tmpdir)
     runner = CliRunner()

--- a/tests/unit_tests/test_datetime.py
+++ b/tests/unit_tests/test_datetime.py
@@ -227,16 +227,20 @@ def test_datetime_to_timestamp_errors():
 
 
 expected_tzinfo = [
-    ("local", None),
-    ("-0400", datetime.timezone(datetime.timedelta(days=-1, seconds=72000))),
-    ("Z", datetime.timezone.utc),
-    ("+1000", datetime.timezone(datetime.timedelta(seconds=36000))),
-    ("wrong", None),
+    ("local", None, False),
+    ("-0400", datetime.timezone(datetime.timedelta(days=-1, seconds=72000)), False),
+    ("Z", datetime.timezone.utc, False),
+    ("+1000", datetime.timezone(datetime.timedelta(seconds=36000)), False),
+    ("wrong", None, True),
 ]
 
 
-@pytest.mark.parametrize("tz_str,tz_info", expected_tzinfo)
-def test_database_timezone_default(tz_str, tz_info):
+@pytest.mark.parametrize("tz_str,tz_info,error", expected_tzinfo)
+def test_database_timezone_default(tz_str, tz_info, error, caplog):
     db = Database()
     db._db["timezone_default"] = tz_str
     assert db.timezone_default == tz_info
+    if error:
+        assert caplog.messages
+    else:
+        assert not caplog.messages


### PR DESCRIPTION
The `--dump` option tells photomanager to print the indexed photo's info to stdout.

Also:
- Adds error message if timezone string was not parsed
- Allows files in PATHS, not just directories
- Sends more logs to stderr instead of stdout