### PR TITLE
Make check_media_integrity optional

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,3 +86,25 @@ jobs:
         run: "ls -l dist"
       - name: "Check long_description"
         run: "python -m twine check dist/*"
+
+  install:
+    strategy:
+      matrix:
+        os: [ "ubuntu-latest", "windows-latest", "macos-latest" ]
+
+    name: "Verify installation"
+    runs-on: "${{ matrix.os }}"
+
+    steps:
+      - uses: "actions/checkout@v2"
+        with:
+          submodules: 'true'
+      - uses: "actions/setup-python@v2"
+        with:
+          python-version: "3.8"
+      - name: "install package"
+        run: "python -m pip install -e ."
+      - name: "import package"
+        run: "python -c 'import photomanager; print(photomanager.__version__)'"
+      - name: "run photomanager"
+        run: "photomanager -h"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
         run: sudo apt-get install libimage-exiftool-perl ffmpeg
       - name: "Install b3sum"
         run: |
-          sudo wget https://github.com/BLAKE3-team/BLAKE3/releases/download/1.2.0/b3sum_linux_x64_bin -O /usr/local/bin/b3sum
+          sudo wget https://github.com/BLAKE3-team/BLAKE3/releases/latest/download/b3sum_linux_x64_bin -O /usr/local/bin/b3sum
           sudo chmod +x /usr/local/bin/b3sum
       - name: "Install dependencies"
         run: |

--- a/README.rst
+++ b/README.rst
@@ -99,6 +99,11 @@ If the photos are stored on an SSD or RAID array, use
 ``--storage-type SSD`` or ``--storage-type RAID`` and
 checksum and EXIF checks will be performed by multiple workers.
 
+To check the integrity of media files before indexing them,
+use the ``--check-integrity`` flag.
+Integrity checking has optional dependencies; install them with
+``pip install .[check-mi]``
+
 Collect files into a storage folder
 -----------------------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,20 +33,6 @@ install_requires =
     zstandard>=0.15.2
     xxhash>=2.0.2
     blake3~=0.3.0
-    ffmpeg-python
-    Pillow-SIMD ; platform_machine=="i386"
-    Pillow-SIMD ; platform_machine=="x86"
-    Pillow-SIMD ; platform_machine=="x64"
-    Pillow-SIMD ; platform_machine=="x86_64"
-    Pillow ; platform_machine=="arm"
-    Pillow ; platform_machine=="armv7l"
-    Pillow ; platform_machine=="aarch64"
-    Pillow ; platform_machine=="arm64"
-    PyPDF2
-    Wand
-    filetype
-    pyheif
-    psutil
 python_requires = >=3.8
 package_dir =
     = src
@@ -70,6 +56,24 @@ test =
     pytest
     pytest-datafiles
     coverage
+check-mi =
+    ffmpeg-python
+    Pillow-SIMD ; platform_machine=="i386"
+    Pillow-SIMD ; platform_machine=="x86"
+    Pillow-SIMD ; platform_machine=="x64"
+    Pillow-SIMD ; platform_machine=="x86_64"
+    Pillow ; platform_machine=="arm"
+    Pillow ; platform_machine=="arm32"
+    Pillow ; platform_machine=="armv7l"
+    Pillow ; platform_machine=="aarch64"
+    Pillow ; platform_machine=="armv8b"
+    Pillow ; platform_machine=="armv8l"
+    Pillow ; platform_machine=="arm64"
+    PyPDF2
+    Wand
+    filetype
+    pyheif
+    psutil
 
 # content of: tox.ini , put in same dir as setup.py
 [tox:tox]
@@ -92,6 +96,8 @@ deps =
 conda_deps =
     imagemagick
     ffmpeg
+extras =
+    check-mi
 ;install_command = pip install --no-compile {opts} {packages}
 commands =
     coverage run -m pytest
@@ -105,7 +111,7 @@ deps =
 commands =
     black --check --diff .
     isort --check --diff .
-    flake8 --count src tests benchmarks --extend-exclude 'src/photomanager/check_media_integrity'
+    flake8 --count src tests benchmarks
 
 [testenv:twine]
 deps =
@@ -135,7 +141,9 @@ per-file-ignores = __init__.py:F401
 extend-ignore =
 # See https://github.com/PyCQA/pycodestyle/issues/373
     E203,W503
-exclude = .*/, build, __pycache__, *.egg, src/photomanager/_version.py
+extend-exclude =
+    src/photomanager/_version.py
+    src/photomanager/check_media_integrity
 
 [coverage:run]
 branch = True

--- a/src/photomanager/cli.py
+++ b/src/photomanager/cli.py
@@ -11,9 +11,17 @@ import click
 
 from photomanager import version
 from photomanager.actions import actions, fileops
-from photomanager.check_media_integrity.check_mi import check_files
 from photomanager.database import Database, sizeof_fmt
 from photomanager.hasher import DEFAULT_HASH_ALGO, HASH_ALGORITHMS, HashAlgorithm
+
+try:
+    from photomanager.check_media_integrity.check_mi import check_files
+except ImportError as e:
+    check_files_message = str(e)
+
+    def check_files(*_, **__):
+        raise Exception("check-media-integrity not available: " + check_files_message)
+
 
 DEFAULT_DB = "photos.json"
 

--- a/tests/unit_tests/test_cli_no_cmi.py
+++ b/tests/unit_tests/test_cli_no_cmi.py
@@ -1,0 +1,68 @@
+import importlib
+import logging
+import sys
+from pathlib import Path
+from typing import cast
+
+import pytest
+from click import Group
+from click.testing import CliRunner
+
+FIXTURE_DIR = Path(__file__).resolve().parent.parent / "test_files"
+
+
+def check_dir_empty(dir_path):
+    cwd_files = list(Path(dir_path).glob("*"))
+    print(cwd_files)
+    assert len(cwd_files) == 0
+
+
+@pytest.fixture(params=(False, True, False))
+def hide_cmi(request, monkeypatch):
+    if request.param:
+        monkeypatch.setitem(
+            sys.modules, "photomanager.check_media_integrity.check_mi", None
+        )
+    return request.param
+
+
+@pytest.mark.datafiles(
+    FIXTURE_DIR / "A" / "img1.png",
+    FIXTURE_DIR / "A" / "img1.jpg",
+)
+def test_cli_check_integrity_not_available(hide_cmi, datafiles, caplog):
+    """
+    If importing check_media_integrity gives an ImportError
+    and the --check-integrity flag is provided, raise an Exception.
+    However, no Exception is raised if --check-integrity is absent.
+    """
+    caplog.set_level(logging.DEBUG)
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=datafiles) as fs:
+        from photomanager import cli
+
+        importlib.reload(cli)
+
+        result = runner.invoke(
+            cast(Group, cli.main),
+            ["index", "--dump", str(datafiles)],
+        )
+        print(result.output)
+        print(result)
+        print(result.exception)
+        assert not result.exception
+        caplog.clear()
+
+        result = runner.invoke(
+            cast(Group, cli.main),
+            ["index", "--dump", "--check-integrity", str(datafiles)],
+        )
+        print(result.output)
+        print(result)
+        print(result.exception)
+        if hide_cmi:
+            assert result.exception
+            assert "check-media-integrity not available:" in str(result.exception)
+        else:
+            assert not result.exception
+        check_dir_empty(fs)


### PR DESCRIPTION
Verify that photomanager can be imported and run after pip install.