### PR TITLE
Support tox 4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -78,8 +78,6 @@ check-mi =
 # content of: tox.ini , put in same dir as setup.py
 [tox:tox]
 envlist = linters, twine, py38, py39, py310, coverage-report
-isolated_build = True
-requires = tox-conda; platform_system=="Darwin"
 
 [gh-actions]
 python =
@@ -93,9 +91,6 @@ deps =
     pytest
     pytest-datafiles
     coverage
-conda_deps =
-    imagemagick
-    ffmpeg
 extras =
     check-mi
 ;install_command = pip install --no-compile {opts} {packages}


### PR DESCRIPTION
Support for tox 4 requires tox-conda to be updated. Also, tox 4 may not support the platform-specific require of tox-conda.