### PR TITLE
Fix hang in AsyncExifTool.do_job()

### DIFF
--- a/src/photomanager/pyexiftool/pyexiftool_async.py
+++ b/src/photomanager/pyexiftool/pyexiftool_async.py
@@ -154,7 +154,7 @@ class AsyncExifTool(AsyncWorkerQueue):
             process.stdin.write(b"\n-execute\n")
             await process.stdin.drain()
             outputs = [b""]
-            while not outputs[-1][-32:].strip().endswith(sentinel):
+            while not b"".join(outputs[-2:]).strip()[-32:].endswith(sentinel):
                 outputs.append(await process.stdout.read(block_size))
             output_bytes = b"".join(outputs).strip()[: -len(sentinel)]
             if len(output_bytes.strip()) == 0:


### PR DESCRIPTION
exiftool outputs a sentinel string `b"{ready}"` when it is done outputting metadata for a given batch. Previously the code would read strings of a certain block_size from exiftool's stdout in a while loop that breaks when the sentinel is detected in the last block. However, if the sentinel was split across two blocks, the program would hang indefinitely.

Instead of checking the last block, check the concatenation of the last two blocks for the sentinel string.