### PR TITLE
Add async timeout to AsyncWorkerQueue

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ orjson>=3.5.2
 zstandard>=0.15.2
 xxhash>=2.0.2
 blake3>=0.2.1
+async-timeout
 pytest
 pytest-cov
 pytest-datafiles

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
     zstandard>=0.15.2
     xxhash>=2.0.2
     blake3~=0.3.0
+    async-timeout; python_version < '3.11'
 python_requires = >=3.10
 package_dir =
     = src

--- a/src/photomanager/async_base.py
+++ b/src/photomanager/async_base.py
@@ -4,7 +4,7 @@ import logging
 import sys
 import time
 import traceback
-from asyncio import Queue, Task, create_task, gather
+from asyncio import Queue, Task, create_task, gather, get_event_loop
 
 if sys.version_info >= (3, 11):
     from asyncio import timeout
@@ -89,6 +89,7 @@ class AsyncWorkerQueue:
                     async with timeout(self.job_timeout):
                         await self.do_job(worker_id, job)
                 except (Exception,):
+                    print(get_event_loop().time())
                     logging.getLogger(__name__).warning(
                         f"{self.__class__.__name__} worker encountered an exception!\n"
                         f"hasher job: {job}\n"

--- a/src/photomanager/async_base.py
+++ b/src/photomanager/async_base.py
@@ -89,10 +89,10 @@ class AsyncWorkerQueue:
                     async with timeout(self.job_timeout):
                         await self.do_job(worker_id, job)
                 except (Exception,):
-                    print(get_event_loop().time())
                     logging.getLogger(__name__).warning(
                         f"{self.__class__.__name__} worker encountered an exception!\n"
                         f"hasher job: {job}\n"
+                        f"loop time:  {get_event_loop().time()}\n"
                         f"{traceback.format_exc()}",
                     )
                 finally:

--- a/src/photomanager/async_base.py
+++ b/src/photomanager/async_base.py
@@ -95,9 +95,9 @@ class AsyncWorkerQueue:
                         f"{traceback.format_exc()}",
                     )
                 finally:
-                    self.queue.task_done()
                     if self.show_progress:
                         self.update_pbar(job)
+                    self.queue.task_done()
         finally:
             await self.close_worker(worker_id)
 

--- a/src/photomanager/async_base.py
+++ b/src/photomanager/async_base.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
 import logging
+import sys
 import time
 import traceback
 from asyncio import Queue, Task, create_task, gather
+
+if sys.version_info >= (3, 11):
+    from asyncio import timeout
+else:
+    from async_timeout import timeout
+
 from collections.abc import Collection, Generator, Iterable
 from dataclasses import dataclass
 from os import cpu_count
@@ -39,9 +46,11 @@ class AsyncWorkerQueue:
         self,
         num_workers: int = cpu_count() or 1,
         show_progress: bool = False,
+        job_timeout: int | float | None = None,
     ):
         self.num_workers: int = num_workers
         self.show_progress: bool = show_progress
+        self.job_timeout: int | float | None = job_timeout
         self.queue: Optional[Queue[AsyncJob]] = None
         self.workers: list[Task] = []
         self.output_dict: dict = {}
@@ -77,9 +86,8 @@ class AsyncWorkerQueue:
                     break
                 job: AsyncJob = await self.queue.get()
                 try:
-                    await self.do_job(worker_id, job)
-                    if self.show_progress:
-                        self.update_pbar(job)
+                    async with timeout(self.job_timeout):
+                        await self.do_job(worker_id, job)
                 except (Exception,):
                     logging.getLogger(__name__).warning(
                         f"{self.__class__.__name__} worker encountered an exception!\n"
@@ -88,6 +96,8 @@ class AsyncWorkerQueue:
                     )
                 finally:
                     self.queue.task_done()
+                    if self.show_progress:
+                        self.update_pbar(job)
         finally:
             await self.close_worker(worker_id)
 

--- a/src/photomanager/hasher.py
+++ b/src/photomanager/hasher.py
@@ -169,9 +169,12 @@ class AsyncFileHasher(AsyncWorkerQueue):
         batch_size: int = 50,
         algorithm: HashAlgorithm = DEFAULT_HASH_ALGO,
         use_async: bool = True,
+        job_timeout: int | float | None = None,
     ):
         super(AsyncFileHasher, self).__init__(
-            num_workers=num_workers, show_progress=show_progress
+            num_workers=num_workers,
+            show_progress=show_progress,
+            job_timeout=job_timeout,
         )
         self.batch_size: int = batch_size
         self.algorithm = algorithm

--- a/src/photomanager/pyexiftool/pyexiftool_async.py
+++ b/src/photomanager/pyexiftool/pyexiftool_async.py
@@ -115,10 +115,13 @@ class AsyncExifTool(AsyncWorkerQueue):
         executable_: str = "",
         num_workers: int = os.cpu_count() or 1,
         show_progress: bool = True,
+        job_timeout: int | float | None = 360,
         batch_size: int = 20,
     ):
         super(AsyncExifTool, self).__init__(
-            num_workers=num_workers, show_progress=show_progress
+            num_workers=num_workers,
+            show_progress=show_progress,
+            job_timeout=job_timeout,
         )
         self.executable = executable if not executable_ else executable_
         self.running = False

--- a/tests/unit_tests/test_async_base.py
+++ b/tests/unit_tests/test_async_base.py
@@ -1,6 +1,12 @@
 import logging
+import sys
 from asyncio import run, sleep
 from dataclasses import dataclass
+
+if sys.version_info >= (3, 11):
+    from asyncio import timeout
+else:
+    from async_timeout import timeout
 
 import pytest
 
@@ -101,6 +107,17 @@ def test_async_execute_queue():
     worker = AsyncTimeoutWorker(num_workers=2, job_timeout=0.0002)
     all_jobs = [TimeoutJob(t) for t in (0.0001, 0.00005, 0.00015)]
     assert run(worker.execute_queue(all_jobs)) == {}
+
+
+def test_async_execute_queue_multiple_workers():
+    worker = AsyncTimeoutWorker(num_workers=8, job_timeout=0.002)
+    all_jobs = [TimeoutJob(0.001) for _ in range(8)]
+
+    async def run_timeout():
+        async with timeout(0.002):
+            return await worker.execute_queue(all_jobs)
+
+    assert run(run_timeout()) == {}
 
 
 def test_async_execute_queue_timeout_error(caplog):


### PR DESCRIPTION
Timeout applies to each job, to catch jobs that hang indefinitely.

Sets timeout for pyexiftool to 5 minutes per job, which seems reasonably conservative.

No timeout applied to the hasher jobs, whose runtime varies widely depending on the file size.